### PR TITLE
[FIX] Resolves random zlib errors on Linux

### DIFF
--- a/lib/redshift_connector/url_data_file.rb
+++ b/lib/redshift_connector/url_data_file.rb
@@ -1,5 +1,6 @@
 require 'redshift_connector/abstract_data_file'
-require 'open3'
+require 'net/http'
+require 'stringio'
 
 module RedshiftConnector
   class UrlDataFile < AbstractDataFile
@@ -15,10 +16,13 @@ module RedshiftConnector
     end
 
     def open
-      stdin, stdout, stderr, wait_th = Open3.popen3('curl', @url.to_s)
-      stdin.close
-      stderr.close
-      stdout
+      http = Net::HTTP.new(@url.host, @url.port)
+      http.use_ssl = (@url.scheme.downcase == 'https')
+      content = http.start {
+        res = http.get(@url.request_uri)
+        res.body
+      }
+      StringIO.new(content)
     end
   end
 end


### PR DESCRIPTION
This pull request fixes random zlib errors occured on (only) Linux.
The error is like this:
```
.../bundle/ruby/2.2.0/gems/redshift-connector-data_file-7.1.0/lib/redshift_connector/reader/redshift_csv.rb:23:in `each_line': unexpected end of file (Zlib::GzipFile::Error)
```
In my inspection, curl correctly read all content from S3, but zlib raises errors.  It seems mixing zlib + pipe IO on Linux causes unexpected I/O problem.  I resolve this problem by not giving pipes to zlib.
