### PR TITLE
fix: Reader::RedshiftCSV: Supports multi-line CSV rows

### DIFF
--- a/lib/redshift_connector/reader/redshift_csv.rb
+++ b/lib/redshift_connector/reader/redshift_csv.rb
@@ -15,41 +15,105 @@ module RedshiftConnector
     # f :: IO
     def initialize(f)
       @f = f
+      @s = ScanBuffer.new(@f)
     end
 
-    def each
-      # We can use simple #each_line to read single row
-      # because line terminators are always escaped by UNLOAD.
-      @f.each_line do |line|
-        yield parse_row(line, @f.lineno)
+    def each_row
+      s = @s
+      while row = parse_row(@s)
+        yield row
       end
     end
 
-    def parse_row(line, lineno = nil)
+    alias each each_row
+
+    def read_row
+      return nil if @s.eof?
+      parse_row(@s)
+    end
+
+    private
+
+    def parse_row(s)
+      s.next_row or return nil
       row = []
-      s = StringScanner.new(line)
-      s.skip(/\s+/)
-      until s.eos?
-        col = s.scan(/"(?:\\.|[^"\\]+)*"/) or raise Reader::MalformedCSVException, "CSV parse error at line #{lineno}"
-        row.push unescape_column(col)
-        s.skip(/\s*/)    # skip line terminator on line ends
-        s.skip(/,\s*/)
+      begin
+        first = false
+        column = s.scan_column
+        unless column
+          raise Reader::MalformedCSVException, "CSV parse error: unterminated column or row at line #{s.lineno}"
+        end
+        row.push unescape_column(column)
+      end while s.read_separator
+      unless s.read_eol
+        raise Reader::MalformedCSVException, "CSV parse error: missing column separator at line #{s.lineno}"
       end
       row
     end
 
     UNESCAPE_MAP = {
-      '\\"' => '"',
-      "\\'" => "'",
-      '\\,' => ',',
+      '\\t' => "\t",
       '\\r' => "\r",
       '\\n' => "\n",
-      '\\\\' => '\\'
     }
 
     def unescape_column(col)
       charmap = UNESCAPE_MAP
-      col[1...-1].gsub(/\\./) {|s| charmap[s] }
+      col[1...-1].gsub(/\\./m) {|s| charmap[s] || s[1,1] }
+    end
+
+    class ScanBuffer
+      def initialize(f)
+        @f = f
+        @s = StringScanner.new("")
+        @eof = false
+      end
+
+      def eof?
+        @s.eos? && @eof
+      end
+
+      def lineno
+        @f.lineno
+      end
+
+      def next_row
+        fill_buffer
+      end
+
+      MAX_COLUMN_LENGTH = (1.2 * (1024 ** 3)).to_i   # 1.2MB
+
+      def scan_column
+        s = @s
+        s.skip(/[ \t]+/)
+        until column = s.scan(/"(?:\\.|[^"\\]+)*"/m)
+          fill_buffer or return nil
+          return nil if s.eos?
+          if s.rest_size > MAX_COLUMN_LENGTH
+            raise Reader::MalformedCSVException, "CSV parse error: too long column at line #{@f.lineno}"
+          end
+        end
+        column
+      end
+
+      def fill_buffer
+        line = @f.gets
+        if line
+          @s << line
+          true
+        else
+          @eof = true
+          false
+        end
+      end
+
+      def read_separator
+        @s.skip(/[ \t]*,/)
+      end
+
+      def read_eol
+        @s.skip(/[ \t\r]*(?:\n|\z)/)
+      end
     end
   end
 end


### PR DESCRIPTION
RedshiftのUNLOADは改行を `\\n` と（バックスラッシュ + N として）ダンプすると信じていたしコードにもコメント付きでそういう想定が書いてあったのですが、実は `\\\n` （バックスラッシュ + 改行文字）をダンプすることが判明しました。

しかたないのでカラムの中に改行文字自体が入ることを許容します。

@bricolages/all おねがいします。