### PR TITLE
Fix regex backtrack explosion in long multiline column

### DIFF
--- a/lib/redshift_connector/reader/redshift_csv.rb
+++ b/lib/redshift_connector/reader/redshift_csv.rb
@@ -86,7 +86,7 @@ module RedshiftConnector
       def scan_column
         s = @s
         s.skip(/[ \t]+/)
-        until column = s.scan(/"(?:\\.|[^"\\]+)*"/m)
+        until column = s.scan(/"(?:\\.|[^"\\])*"/m)
           fill_buffer or return nil
           return nil if s.eos?
           if s.rest_size > MAX_COLUMN_LENGTH

--- a/test/reader/test_redshift_csv.rb
+++ b/test/reader/test_redshift_csv.rb
@@ -29,6 +29,9 @@ module RedshiftConnector
         assert_equal ['981179', '2017-01-07', '6', '852', 'show', '{"page"=>"4"}', '1', '1'],
           parse_row(%Q("981179","2017-01-07","6","852","show","{\\"page\\"=>\\"4\\"}","1","1"\n))
 
+        assert_equal ['x,x', "longdatalongdatalongdatalongdatalongdatalongdatalongdata\ntrailingdata\n", 'z"z', 'a\\a'],
+          parse_row(%Q("x\\,x","longdatalongdatalongdatalongdatalongdatalongdatalongdata\\\ntrailingdata\\\n","z\\"z","a\\\\a"\n))
+
         assert_raises RedshiftConnector::Reader::MalformedCSVException do
           parse_row(%Q("xxx,"yyy"))
         end


### PR DESCRIPTION
This PR fixes the regexp backtrack explosion in parsing a long multi-line column.

@aamine please review